### PR TITLE
feat: Package.swift with CStockfish and LucidEngine targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,37 @@
 // swift-tools-version: 6.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "lucid-engine",
+    name: "LucidEngine",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
-            name: "lucid-engine",
-            targets: ["lucid-engine"]
+            name: "LucidEngine",
+            targets: ["LucidEngine"]
         ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "lucid-engine"
+            name: "CStockfish",
+            path: "Sources/CStockfish",
+            sources: ["src/"],
+            publicHeadersPath: "include"
         ),
+
+        .target(
+            name: "LucidEngine",
+            dependencies: ["CStockfish"],
+            path: "Sources/LucidEngine"
+        ),
+
         .testTarget(
-            name: "lucid-engineTests",
-            dependencies: ["lucid-engine"]
+            name: "LucidEngineTests",
+            dependencies: ["LucidEngine"],
+            path: "Tests/LucidEngineTests"
         ),
     ]
 )

--- a/Sources/CStockfish/include/stockfish_bridge.h
+++ b/Sources/CStockfish/include/stockfish_bridge.h
@@ -1,0 +1,27 @@
+#ifndef STOCKFISH_BRIDGE_H
+#define STOCKFISH_BRIDGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Max buffer size for UCI move strings (e.g. "e2e4\0", "e7e8q\0").
+#define SF_MOVE_BUF_SIZE 8
+
+/// Returns 0 on success, non-zero on failure.
+int sf_init(void);
+
+void sf_cleanup(void);
+
+/// Returns centipawn score from white's perspective.
+int sf_assess_position(const char* fen, int depth);
+
+/// Writes UCI move string to out_move. Use SF_MOVE_BUF_SIZE for buf_size.
+/// Returns 0 on success, non-zero on failure.
+int sf_best_move(const char* fen, int depth, char* out_move, int buf_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STOCKFISH_BRIDGE_H */

--- a/Sources/CStockfish/src/stockfish_bridge.c
+++ b/Sources/CStockfish/src/stockfish_bridge.c
@@ -1,0 +1,18 @@
+#include "stockfish_bridge.h"
+
+// Placeholder stubs -- replaced with real Stockfish integration in Issue #3.
+
+int sf_init(void) {
+    return 0;
+}
+
+void sf_cleanup(void) {
+}
+
+int sf_assess_position(const char* fen, int depth) {
+    return 0;
+}
+
+int sf_best_move(const char* fen, int depth, char* out_move, int buf_size) {
+    return -1; // Not implemented
+}

--- a/Sources/LucidEngine/Engine/EngineError.swift
+++ b/Sources/LucidEngine/Engine/EngineError.swift
@@ -1,0 +1,6 @@
+public enum EngineError: Error, Sendable {
+    case initializationFailed
+    case notInitialized
+    case invalidDepth(Int)
+    case invalidFEN
+}

--- a/Sources/LucidEngine/Engine/LucidEngine.swift
+++ b/Sources/LucidEngine/Engine/LucidEngine.swift
@@ -1,0 +1,25 @@
+internal import CStockfish
+
+public actor LucidEngine {
+
+    public private(set) var isInitialized = false
+
+    public init() {}
+
+    /// Idempotent. Safe to call multiple times.
+    public func start() throws {
+        guard !isInitialized else { return }
+        let status = sf_init()
+        guard status == 0 else {
+            throw EngineError.initializationFailed
+        }
+        isInitialized = true
+    }
+
+    /// Callers must call shutdown() explicitly before releasing the engine.
+    public func shutdown() {
+        guard isInitialized else { return }
+        sf_cleanup()
+        isInitialized = false
+    }
+}

--- a/Sources/lucid-engine/lucid_engine.swift
+++ b/Sources/lucid-engine/lucid_engine.swift
@@ -1,2 +1,0 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book

--- a/Tests/LucidEngineTests/PackageStructureTests.swift
+++ b/Tests/LucidEngineTests/PackageStructureTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import LucidEngine
+
+// MARK: - Package Structure Smoke Tests
+//
+// Prove Issue #1 is complete:
+// - Package.swift compiles with CStockfish + LucidEngine targets
+// - LucidEngine module is importable
+// - C bridge symbols are reachable through the actor
+// - Basic lifecycle (start/shutdown) does not crash
+
+@Suite("Package Structure")
+struct PackageStructureTests {
+
+    @Test("LucidEngine can be instantiated")
+    func engineInstantiates() async {
+        let engine = LucidEngine()
+        let isInit = await engine.isInitialized
+        #expect(isInit == false)
+    }
+
+    @Test("Engine starts without error")
+    func engineStartSucceeds() async throws {
+        let engine = LucidEngine()
+        try await engine.start()
+        let isInit = await engine.isInitialized
+        #expect(isInit == true)
+    }
+
+    @Test("Engine start is idempotent")
+    func engineStartIsIdempotent() async throws {
+        let engine = LucidEngine()
+        try await engine.start()
+        try await engine.start()
+        let isInit = await engine.isInitialized
+        #expect(isInit == true)
+    }
+
+    @Test("Engine shuts down cleanly")
+    func engineShutdownSucceeds() async throws {
+        let engine = LucidEngine()
+        try await engine.start()
+        await engine.shutdown()
+        let isInit = await engine.isInitialized
+        #expect(isInit == false)
+    }
+
+    @Test("Engine shutdown before start does not crash")
+    func shutdownBeforeStartIsNoop() async {
+        let engine = LucidEngine()
+        await engine.shutdown()
+        let isInit = await engine.isInitialized
+        #expect(isInit == false)
+    }
+}

--- a/Tests/lucid-engineTests/lucid_engineTests.swift
+++ b/Tests/lucid-engineTests/lucid_engineTests.swift
@@ -1,6 +1,0 @@
-import Testing
-@testable import lucid_engine
-
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-}

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,57 +1,89 @@
 # LucidEngine -- Directory Tree
 
-Planned project structure (current + upcoming files).
+Project structure showing implemented files and planned future files.
+
+Legend:
+- No marker = implemented and present on disk
+- `[planned]` = not yet created, part of a future issue
 
 ```
 lucid-engine/
 ├── .claude/                          # Agent configuration
 │   ├── agents/                       # Subagent definitions
+│   │   ├── subagent-docs-analyst.md
+│   │   ├── subagent-engine-architect.md
+│   │   ├── subagent-master-planner.md
+│   │   ├── subagent-qa-engine.md
+│   │   └── subagent-security-analyst.md
 │   ├── commands/                     # Custom commands
+│   │   ├── brainstorm.md
+│   │   ├── implement.md
+│   │   ├── plan-feature.md
+│   │   └── pushup.md
+│   ├── hooks/
+│   │   └── notify.sh
 │   ├── skills/                       # Custom skills
+│   │   └── engine-patterns/
+│   │       ├── assessment.md
+│   │       ├── c-interop.md
+│   │       └── SKILL.md
 │   ├── CLAUDE.md                     # Project instructions
-│   └── NEXT-SESSION.md              # Session bootstrap prompt
+│   ├── NEXT-SESSION.md              # Session bootstrap prompt
+│   ├── settings.json
+│   └── settings.local.json
 ├── docs/
 │   ├── PRD.md                        # Product Requirements Document
 │   └── ARCHITECTURE.md              # Technical architecture blueprint
 ├── Sources/
-│   ├── CStockfish/                   # C/C++ Stockfish target
+│   ├── CStockfish/                   # C/C++ Stockfish target (Issue #1)
 │   │   ├── include/
 │   │   │   └── stockfish_bridge.h   # Public C header for Swift interop
 │   │   └── src/
-│   │       ├── stockfish_bridge.cpp  # C wrapper around Stockfish internals
-│   │       └── (stockfish sources)   # Stockfish C++ source files
+│   │       ├── stockfish_bridge.c   # C bridge implementation
+│   │       └── (stockfish sources)  # [planned] Stockfish C++ source files
 │   └── LucidEngine/                  # Swift public API target
 │       ├── Engine/
-│       │   ├── LucidEngine.swift     # Main actor -- evaluate, bestMove, analyzeGame
-│       │   └── EngineError.swift     # Error types
-│       ├── Models/
-│       │   ├── Score.swift           # Centipawns / mate-in-N
-│       │   ├── Move.swift            # From/to/promotion/UCI
-│       │   ├── Evaluation.swift      # Single position result
-│       │   ├── PositionAssessment.swift  # (alias / convenience)
-│       │   ├── MoveClassification.swift  # brilliant → blunder enum
-│       │   ├── AnalyzedMove.swift    # Per-move analysis result
-│       │   ├── GameAnalysis.swift    # Full game result
-│       │   ├── Accuracy.swift        # White/black accuracy
-│       │   ├── WinProbability.swift  # Win/draw/loss percentages
-│       │   ├── GamePhases.swift      # Opening/middlegame/endgame ranges
-│       │   └── EngineConfiguration.swift  # Threads, hash, depth
-│       └── Analysis/
-│           ├── GameAnalyzer.swift    # Pipeline: FENs → GameAnalysis
-│           ├── AccuracyCalculator.swift  # CPL → accuracy percentage
-│           ├── MoveClassifier.swift  # CPL thresholds → classification
-│           ├── WinProbabilityCalculator.swift  # Centipawns → win%
-│           └── PhaseDetector.swift   # Piece count → game phase
+│       │   ├── LucidEngine.swift     # Main actor skeleton (Issue #1)
+│       │   └── EngineError.swift     # Error types (Issue #1)
+│       ├── Models/                   # [planned]
+│       │   ├── Score.swift           # [planned] Centipawns / mate-in-N
+│       │   ├── Move.swift            # [planned] From/to/promotion/UCI
+│       │   ├── Evaluation.swift      # [planned] Single position result
+│       │   ├── PositionAssessment.swift  # [planned] Alias / convenience
+│       │   ├── MoveClassification.swift  # [planned] brilliant → blunder enum
+│       │   ├── AnalyzedMove.swift    # [planned] Per-move analysis result
+│       │   ├── GameAnalysis.swift    # [planned] Full game result
+│       │   ├── Accuracy.swift        # [planned] White/black accuracy
+│       │   ├── WinProbability.swift  # [planned] Win/draw/loss percentages
+│       │   ├── GamePhases.swift      # [planned] Opening/middlegame/endgame ranges
+│       │   └── EngineConfiguration.swift  # [planned] Threads, hash, depth
+│       └── Analysis/                 # [planned]
+│           ├── GameAnalyzer.swift    # [planned] Pipeline: FENs → GameAnalysis
+│           ├── AccuracyCalculator.swift  # [planned] CPL → accuracy percentage
+│           ├── MoveClassifier.swift  # [planned] CPL thresholds → classification
+│           ├── WinProbabilityCalculator.swift  # [planned] Centipawns → win%
+│           └── PhaseDetector.swift   # [planned] Piece count → game phase
 ├── Tests/
 │   └── LucidEngineTests/
-│       ├── EngineLifecycleTests.swift       # Init, start, stop, reinit
-│       ├── PositionAssessmentTests.swift    # Known positions, edge cases
-│       ├── MoveClassificationTests.swift    # CPL → classification mapping
-│       ├── GameAnalysisTests.swift          # Full pipeline tests
-│       └── PerformanceBenchmarkTests.swift  # Timing & memory benchmarks
-├── Package.swift                     # SPM manifest (CStockfish + LucidEngine)
+│       ├── PackageStructureTests.swift      # SPM scaffold verification (Issue #1)
+│       ├── EngineLifecycleTests.swift       # [planned] Init, start, stop, reinit
+│       ├── PositionAssessmentTests.swift    # [planned] Known positions, edge cases
+│       ├── MoveClassificationTests.swift    # [planned] CPL → classification mapping
+│       ├── GameAnalysisTests.swift          # [planned] Full pipeline tests
+│       └── PerformanceBenchmarkTests.swift  # [planned] Timing & memory benchmarks
+├── Package.swift                     # SPM manifest (CStockfish + LucidEngine, swift-tools-version: 6.2)
 ├── README.md                         # Project overview & quick start
 ├── directory-tree.md                 # This file
-├── LICENSE                           # MIT
+├── LICENSE                           # [planned] MIT
 └── .gitignore                        # Build artifacts, .DS_Store, etc.
 ```
+
+## Issue Status
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| #1 | SPM package scaffold -- CStockfish + LucidEngine targets, bridge header, actor skeleton | Done |
+| #2 | Stockfish C++ source integration and build pipeline | Planned |
+| #3 | UCI communication layer (pipe-based I/O) | Planned |
+| #4 | Evaluation models and score parsing | Planned |
+| #5 | Game analysis pipeline and move classification | Planned |


### PR DESCRIPTION
## Summary
- Set up SPM package with CStockfish (C bridge) and LucidEngine (Swift actor) targets
- Added placeholder C bridge header (`stockfish_bridge.h`) with `SF_MOVE_BUF_SIZE` constant and stub implementation
- Created `LucidEngine` actor with start/shutdown lifecycle and `EngineError` enum
- 5 smoke tests verifying package structure, C bridge reachability, and lifecycle idempotency

Closes #1

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` passes (5/5 tests)
- [x] Package structure matches `directory-tree.md`
- [x] Security review completed (no issues for stubs; forward-looking items tracked)