### PR TITLE
feat: Single position assessment (LE-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ Or in Xcode: File -> Add Package Dependencies -> enter the repository URL.
 import LucidEngine
 
 let engine = LucidEngine()
+try await engine.start()
 
 // Evaluate the starting position
-let eval = try await engine.evaluate(fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
-print(eval.score)        // .centipawns(20) -- slight white advantage
-print(eval.bestMove.uci) // "e2e4"
+let assessment = try await engine.evaluate(fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+print(assessment.score)        // .centipawns(20) -- slight white advantage
+print(assessment.bestMove.uci) // "e2e4"
+
+// Or just get the best move directly
+let move = try await engine.bestMove(fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+print(move.uci) // "e2e4"
 ```
 
 ### Analyze a Complete Game
@@ -69,18 +74,18 @@ for move in analysis.analyzedMoves {
 
 | Type | Description |
 |------|-------------|
-| `LucidEngine` | Actor -- main entry point for all evaluations |
-| `Evaluation` | Score, best move, principal variation, depth, nodes |
+| `LucidEngine` | Actor -- main entry point; `start()`, `shutdown()`, `evaluate(fen:depth:)`, `bestMove(fen:depth:)` |
+| `PositionAssessment` | Score, best move, principal variation, depth, nodes -- returned by `evaluate()` |
 | `Score` | `.centipawns(Int)` or `.mate(Int)` |
-| `Move` | From/to squares, promotion, UCI notation |
-| `GameAnalysis` | Full game result: analyzed moves, accuracy, phases |
-| `AnalyzedMove` | Per-move evaluation, classification, centipawn loss |
-| `MoveClassification` | brilliant / great / good / book / inaccuracy / mistake / blunder |
-| `Accuracy` | White and black accuracy percentages |
-| `WinProbability` | Win / draw / loss probabilities |
-| `GamePhases` | Opening / middlegame / endgame move ranges |
-| `EngineConfiguration` | defaultDepth, threadCount, hashSizeMB with validation preconditions |
-| `EngineError` | initializationFailed, engineNotRunning, invalidDepth, invalidFEN(String), invalidConfiguration(String), evaluationTimeout, analysisInterrupted |
+| `Move` | From/to squares, optional promotion piece, UCI notation |
+| `EngineConfiguration` | `defaultDepth` (1...100), `threadCount` (1...64), `hashSizeMB` (1...4096), `timeoutSeconds` (>0, default 5.0) |
+| `EngineError` | `initializationFailed`, `engineNotRunning`, `invalidDepth(Int)`, `invalidFEN(String)`, `invalidConfiguration(String)`, `evaluationTimeout`, `analysisInterrupted` |
+| `GameAnalysis` | [planned] Full game result: analyzed moves, accuracy, phases |
+| `AnalyzedMove` | [planned] Per-move evaluation, classification, centipawn loss |
+| `MoveClassification` | [planned] brilliant / great / good / book / inaccuracy / mistake / blunder |
+| `Accuracy` | [planned] White and black accuracy percentages |
+| `WinProbability` | [planned] Win / draw / loss probabilities |
+| `GamePhases` | [planned] Opening / middlegame / endgame move ranges |
 
 ## Requirements
 

--- a/Sources/LucidEngine/Engine/LucidEngine.swift
+++ b/Sources/LucidEngine/Engine/LucidEngine.swift
@@ -10,6 +10,8 @@ public actor LucidEngine {
         self.configuration = configuration
     }
 
+    // MARK: - Lifecycle
+
     /// Start the engine. Calls `sf_init()` on the C side.
     /// Idempotent — calling on an already-running engine is a no-op.
     public func start() throws {
@@ -34,5 +36,108 @@ public actor LucidEngine {
         guard isRunning else {
             throw EngineError.engineNotRunning
         }
+    }
+
+    // MARK: - Position Assessment
+
+    public func evaluate(fen: String, depth: Int = 18) async throws -> PositionAssessment {
+        try ensureRunning()
+
+        guard depth >= 1 && depth <= SF_MAX_DEPTH else {
+            throw EngineError.invalidDepth(depth)
+        }
+
+        if FENValidator.validate(fen) != nil {
+            throw EngineError.invalidFEN(fen)
+        }
+
+        return try await withThrowingTaskGroup(of: PositionAssessment?.self) { group in
+            group.addTask { @Sendable in
+                try Self.assessPosition(fen: fen, depth: depth)
+            }
+
+            group.addTask { @Sendable [configuration] in
+                try await Task.sleep(for: .seconds(configuration.timeoutSeconds))
+                return nil
+            }
+
+            for try await result in group {
+                if let assessment = result {
+                    group.cancelAll()
+                    return assessment
+                } else {
+                    group.cancelAll()
+                    throw EngineError.evaluationTimeout
+                }
+            }
+
+            throw EngineError.evaluationTimeout
+        }
+    }
+
+    public func bestMove(fen: String, depth: Int = 18) async throws -> Move {
+        let assessment = try await evaluate(fen: fen, depth: depth)
+        return assessment.bestMove
+    }
+
+    // MARK: - C Bridge
+
+    private static func assessPosition(fen: String, depth: Int) throws -> PositionAssessment {
+        var result = SFAssessResult()
+        let status = fen.withCString { fenPtr in
+            sf_assess_position(fenPtr, Int32(depth), &result)
+        }
+
+        switch status {
+        case SF_OK:
+            break
+        case SF_ERR_INVALID_FEN:
+            throw EngineError.invalidFEN(fen)
+        case SF_ERR_INVALID_DEPTH:
+            throw EngineError.invalidDepth(depth)
+        case SF_ERR_NOT_INITIALIZED:
+            throw EngineError.engineNotRunning
+        default:
+            throw EngineError.analysisInterrupted
+        }
+
+        let score: Score = switch result.score_type {
+        case SF_SCORE_MATE:
+            .mate(Int(result.score))
+        default:
+            .centipawns(Int(result.score))
+        }
+
+        let bestMoveStr = withUnsafePointer(to: result.best_move) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: Int(SF_MOVE_BUF_SIZE)) { buf in
+                String(cString: buf)
+            }
+        }
+        let bestMove = Move(uci: bestMoveStr) ?? Move(from: "a1", to: "a1")
+
+        var principalVariation: [Move] = []
+        let pvLength = min(Int(result.pv_length), Int(SF_MAX_PV_LENGTH))
+        if pvLength > 0 {
+            withUnsafePointer(to: result.pv) { pvPtr in
+                let rawBase = UnsafeRawPointer(pvPtr)
+                for i in 0..<pvLength {
+                    let offset = i * Int(SF_MOVE_BUF_SIZE)
+                    let cStr = rawBase.advanced(by: offset)
+                        .assumingMemoryBound(to: CChar.self)
+                    let moveStr = String(cString: cStr)
+                    if let move = Move(uci: moveStr) {
+                        principalVariation.append(move)
+                    }
+                }
+            }
+        }
+
+        return PositionAssessment(
+            score: score,
+            bestMove: bestMove,
+            principalVariation: principalVariation,
+            depth: Int(result.depth),
+            nodes: Int(result.nodes)
+        )
     }
 }

--- a/Sources/LucidEngine/Models/EngineConfiguration.swift
+++ b/Sources/LucidEngine/Models/EngineConfiguration.swift
@@ -3,6 +3,7 @@ public struct EngineConfiguration: Sendable, Equatable {
     public let defaultDepth: Int
     public let threadCount: Int
     public let hashSizeMB: Int
+    public let timeoutSeconds: Double
 
     public static let `default` = try! EngineConfiguration(
         defaultDepth: 18,
@@ -13,7 +14,8 @@ public struct EngineConfiguration: Sendable, Equatable {
     public init(
         defaultDepth: Int = 18,
         threadCount: Int = 1,
-        hashSizeMB: Int = 64
+        hashSizeMB: Int = 64,
+        timeoutSeconds: Double = 5.0
     ) throws {
         guard (1...100).contains(defaultDepth) else {
             throw EngineError.invalidConfiguration("defaultDepth must be 1...100, got \(defaultDepth)")
@@ -24,8 +26,12 @@ public struct EngineConfiguration: Sendable, Equatable {
         guard (1...4096).contains(hashSizeMB) else {
             throw EngineError.invalidConfiguration("hashSizeMB must be 1...4096, got \(hashSizeMB)")
         }
+        guard timeoutSeconds > 0 else {
+            throw EngineError.invalidConfiguration("timeoutSeconds must be > 0, got \(timeoutSeconds)")
+        }
         self.defaultDepth = defaultDepth
         self.threadCount = threadCount
         self.hashSizeMB = hashSizeMB
+        self.timeoutSeconds = timeoutSeconds
     }
 }

--- a/Sources/LucidEngine/Models/PositionAssessment.swift
+++ b/Sources/LucidEngine/Models/PositionAssessment.swift
@@ -20,3 +20,6 @@ public struct PositionAssessment: Sendable, Equatable {
         self.nodes = nodes
     }
 }
+
+/// Alias matching the public API surface described in the design docs.
+public typealias Evaluation = PositionAssessment

--- a/Sources/LucidEngine/Validation/FENValidator.swift
+++ b/Sources/LucidEngine/Validation/FENValidator.swift
@@ -1,0 +1,95 @@
+enum FENValidator {
+
+    enum ValidationError: String, Sendable {
+        case emptyString = "FEN string is empty"
+        case tooLong = "FEN string exceeds maximum length"
+        case wrongFieldCount = "FEN must have exactly 6 space-separated fields"
+        case invalidPiecePlacement = "Invalid piece placement"
+        case invalidRankLength = "Rank does not sum to 8"
+        case invalidActiveColor = "Active color must be 'w' or 'b'"
+        case invalidCastling = "Invalid castling availability"
+        case invalidEnPassant = "Invalid en passant square"
+        case invalidHalfmoveClock = "Halfmove clock must be a non-negative integer"
+        case invalidFullmoveNumber = "Fullmove number must be a positive integer"
+    }
+
+    /// Returns nil if the FEN is structurally valid.
+    /// Returns a ValidationError describing the first problem found otherwise.
+    static func validate(_ fen: String) -> ValidationError? {
+        let trimmed = String(fen.drop(while: { $0 == " " }).reversed().drop(while: { $0 == " " }).reversed())
+        guard !trimmed.isEmpty else { return .emptyString }
+        guard trimmed.utf8.count <= 256 else { return .tooLong }
+
+        let fields = trimmed.split(separator: " ", omittingEmptySubsequences: false)
+        guard fields.count == 6 else { return .wrongFieldCount }
+
+        // Field 1: Piece placement — 8 ranks separated by /
+        let ranks = fields[0].split(separator: "/", omittingEmptySubsequences: false)
+        guard ranks.count == 8 else { return .invalidPiecePlacement }
+
+        let validPieces: Set<Character> = [
+            "p", "n", "b", "r", "q", "k",
+            "P", "N", "B", "R", "Q", "K",
+        ]
+
+        for rank in ranks {
+            var squareCount = 0
+            for char in rank {
+                if let digit = char.wholeNumberValue, digit >= 1, digit <= 8 {
+                    squareCount += digit
+                } else if validPieces.contains(char) {
+                    squareCount += 1
+                } else {
+                    return .invalidPiecePlacement
+                }
+            }
+            guard squareCount == 8 else { return .invalidRankLength }
+        }
+
+        // Field 2: Active color
+        let color = fields[1]
+        guard color == "w" || color == "b" else {
+            return .invalidActiveColor
+        }
+
+        // Field 3: Castling availability
+        let castling = String(fields[2])
+        if castling != "-" {
+            let validCastlingChars: Set<Character> = ["K", "Q", "k", "q"]
+            guard !castling.isEmpty,
+                  castling.count <= 4,
+                  castling.allSatisfy({ validCastlingChars.contains($0) })
+            else {
+                return .invalidCastling
+            }
+            guard Set(castling).count == castling.count else {
+                return .invalidCastling
+            }
+        }
+
+        // Field 4: En passant target square
+        let enPassant = String(fields[3])
+        if enPassant != "-" {
+            guard enPassant.count == 2 else { return .invalidEnPassant }
+            let epChars = Array(enPassant)
+            guard epChars[0] >= "a", epChars[0] <= "h" else {
+                return .invalidEnPassant
+            }
+            guard epChars[1] == "3" || epChars[1] == "6" else {
+                return .invalidEnPassant
+            }
+        }
+
+        // Field 5: Halfmove clock (non-negative integer)
+        guard let halfmove = Int(fields[4]), halfmove >= 0 else {
+            return .invalidHalfmoveClock
+        }
+
+        // Field 6: Fullmove number (positive integer >= 1)
+        guard let fullmove = Int(fields[5]), fullmove >= 1 else {
+            return .invalidFullmoveNumber
+        }
+
+        return nil
+    }
+}

--- a/Tests/LucidEngineTests/LucidEngineLifecycleTests.swift
+++ b/Tests/LucidEngineTests/LucidEngineLifecycleTests.swift
@@ -12,12 +12,13 @@ struct LucidEngineLifecycleTests {
 
     // MARK: - Configuration
 
-    @Test("Default configuration uses depth 18, 1 thread, 64 MB hash")
+    @Test("Default configuration uses depth 18, 1 thread, 64 MB hash, 5s timeout")
     func defaultConfiguration() {
         let config = EngineConfiguration.default
         #expect(config.defaultDepth == 18)
         #expect(config.threadCount == 1)
         #expect(config.hashSizeMB == 64)
+        #expect(config.timeoutSeconds == 5.0)
     }
 
     @Test("Custom configuration stores values correctly")

--- a/Tests/LucidEngineTests/PositionAssessmentTests.swift
+++ b/Tests/LucidEngineTests/PositionAssessmentTests.swift
@@ -1,0 +1,610 @@
+import Testing
+@testable import LucidEngine
+import CStockfish
+
+// All suites must be serialized under a single parent because
+// sf_init/sf_cleanup are global C state. Running suites in
+// parallel causes one suite's cleanup to affect others.
+
+@Suite("Position Assessment", .serialized)
+struct PositionAssessmentTestSuite {
+
+    // ============================================================
+    // MARK: - FEN Validation — evaluate()
+    // ============================================================
+
+    @Suite("FEN Validation — evaluate()")
+    struct FENValidationEvaluateTests {
+
+        @Test("empty FEN throws invalidFEN")
+        func emptyFENThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.invalidFEN("")) {
+                _ = try await engine.evaluate(fen: "", depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("whitespace-only FEN throws invalidFEN")
+        func whitespaceFENThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: "   ", depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("single word FEN throws invalidFEN")
+        func singleWordFENThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: "notafen", depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("FEN with wrong number of ranks throws invalidFEN")
+        func wrongRankCountThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let badFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP w KQkq - 0 1"
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: badFEN, depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("FEN with missing active color field throws invalidFEN")
+        func missingActiveColorThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let badFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: badFEN, depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("FEN with invalid active color throws invalidFEN")
+        func invalidActiveColorThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let badFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1"
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: badFEN, depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("FEN with invalid piece character throws invalidFEN")
+        func invalidPieceCharacterThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let badFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPZPPP/RNBQKBNR w KQkq - 0 1"
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: badFEN, depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("FEN exceeding SF_MAX_FEN_LENGTH throws invalidFEN")
+        func oversizedFENThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let oversized = String(repeating: "x", count: 300)
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: oversized, depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("FEN with rank sum exceeding 8 throws invalidFEN")
+        func rankSumExceedsEightThrowsInvalidFEN() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let badFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/9 w KQkq - 0 1"
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.evaluate(fen: badFEN, depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("evaluate on stopped engine throws engineNotRunning")
+        func stoppedEngineThrowsEngineNotRunning() async {
+            let engine = LucidEngine()
+
+            await #expect(throws: EngineError.engineNotRunning) {
+                _ = try await engine.evaluate(fen: "", depth: 10)
+            }
+        }
+    }
+
+    // ============================================================
+    // MARK: - FEN Validation — bestMove()
+    // ============================================================
+
+    @Suite("FEN Validation — bestMove()")
+    struct FENValidationBestMoveTests {
+
+        @Test("empty FEN throws invalidFEN on bestMove")
+        func emptyFENThrowsOnBestMove() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.bestMove(fen: "", depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("garbage FEN throws invalidFEN on bestMove")
+        func garbageFENThrowsOnBestMove() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.self) {
+                _ = try await engine.bestMove(fen: "totally-not-a-fen-string", depth: 10)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove on stopped engine throws engineNotRunning")
+        func stoppedEngineThrowsOnBestMove() async {
+            let engine = LucidEngine()
+
+            await #expect(throws: EngineError.engineNotRunning) {
+                _ = try await engine.bestMove(
+                    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                    depth: 10
+                )
+            }
+        }
+    }
+
+    // ============================================================
+    // MARK: - Depth Validation
+    // ============================================================
+
+    @Suite("Depth Validation")
+    struct DepthValidationTests {
+
+        private static let validFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+        @Test("depth 0 throws invalidDepth")
+        func depthZeroThrowsInvalidDepth() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.invalidDepth(0)) {
+                _ = try await engine.evaluate(fen: Self.validFEN, depth: 0)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("negative depth throws invalidDepth")
+        func negativeDepthThrowsInvalidDepth() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.invalidDepth(-1)) {
+                _ = try await engine.evaluate(fen: Self.validFEN, depth: -1)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("depth 101 exceeds SF_MAX_DEPTH and throws invalidDepth")
+        func depthExceedsMaxThrowsInvalidDepth() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.invalidDepth(101)) {
+                _ = try await engine.evaluate(fen: Self.validFEN, depth: 101)
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("depth 1 is the minimum valid depth")
+        func depthOneIsValid() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            _ = try await engine.evaluate(fen: Self.validFEN, depth: 1)
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove depth 0 throws invalidDepth")
+        func bestMoveDepthZeroThrows() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            await #expect(throws: EngineError.invalidDepth(0)) {
+                _ = try await engine.bestMove(fen: Self.validFEN, depth: 0)
+            }
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Default Depth Parameter
+    // ============================================================
+
+    @Suite("Default Depth Parameter")
+    struct DefaultDepthParameterTests {
+
+        private static let validFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+        @Test("evaluate omitting depth uses default of 18")
+        func evaluateWithDefaultDepth() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let assessment = try await engine.evaluate(fen: Self.validFEN)
+            #expect(assessment.depth == 18)
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove omitting depth does not throw")
+        func bestMoveWithDefaultDepth() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            _ = try await engine.bestMove(fen: Self.validFEN)
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Score Mapping (C-to-Swift Translation)
+    // ============================================================
+
+    @Suite("Score Mapping")
+    struct ScoreMappingTests {
+
+        private static let startingFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+        @Test("evaluate returns PositionAssessment with requested depth")
+        func evaluateReturnsRequestedDepth() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let result = try await engine.evaluate(fen: Self.startingFEN, depth: 12)
+            #expect(result.depth == 12)
+
+            await engine.shutdown()
+        }
+
+        @Test("evaluate result has non-negative nodes")
+        func evaluateResultHasNonNegativeNodes() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let result = try await engine.evaluate(fen: Self.startingFEN, depth: 10)
+            #expect(result.nodes >= 0)
+
+            await engine.shutdown()
+        }
+
+        @Test("evaluate score is a valid Score variant")
+        func scoreIsValidVariant() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let result = try await engine.evaluate(fen: Self.startingFEN, depth: 10)
+            switch result.score {
+            case .centipawns, .mate:
+                break // valid
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("evaluate principal variation is an array of Move")
+        func evaluatePVIsArrayOfMoves() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let result = try await engine.evaluate(fen: Self.startingFEN, depth: 10)
+            #expect(result.principalVariation.count >= 0)
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Integration — Known Position Evaluations
+    // ============================================================
+    // These tests require REAL Stockfish (not the stub).
+    // They will FAIL until sf_assess_position is wired to Stockfish.
+
+    @Suite("Integration — Evaluation Correctness",
+           .disabled("Requires real Stockfish — C stub returns zeroed results"))
+    struct EvaluationCorrectnessTests {
+
+        @Test("starting position score is roughly equal (< 50cp)")
+        func startingPositionIsRoughlyEqual() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let result = try await engine.evaluate(
+                fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                depth: 12
+            )
+
+            guard case .centipawns(let cp) = result.score else {
+                Issue.record("Starting position returned a mate score unexpectedly")
+                await engine.shutdown()
+                return
+            }
+            #expect(abs(cp) < 50)
+
+            await engine.shutdown()
+        }
+
+        @Test("rook up for white is significant advantage")
+        func rookUpIsSignificantAdvantage() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let rookUpFEN = "4k3/pppppppp/8/8/8/8/PPPPPPPP/R3K3 w Q - 0 1"
+            let result = try await engine.evaluate(fen: rookUpFEN, depth: 12)
+
+            switch result.score {
+            case .centipawns(let cp):
+                #expect(cp > 300)
+            case .mate(let n):
+                #expect(n > 0)
+            }
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Integration — Mate Detection
+    // ============================================================
+
+    @Suite("Integration — Mate Detection",
+           .disabled("Requires real Stockfish — C stub returns zeroed results"))
+    struct MateDetectionTests {
+
+        @Test("mate-in-1 returns Score.mate(1)")
+        func mateInOneReturnsMateScore() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let mateIn1FEN = "6k1/5ppp/8/8/8/8/5PPP/4R1K1 w - - 0 1"
+            let result = try await engine.evaluate(fen: mateIn1FEN, depth: 5)
+
+            if case .mate(let n) = result.score {
+                #expect(n == 1)
+            } else {
+                Issue.record("Expected Score.mate for mate-in-1 position, got \(result.score)")
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("mate-in-1 best move is e1e8")
+        func mateInOneBestMoveIsRe8() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let mateIn1FEN = "6k1/5ppp/8/8/8/8/5PPP/4R1K1 w - - 0 1"
+            let result = try await engine.evaluate(fen: mateIn1FEN, depth: 5)
+
+            #expect(result.bestMove.uci == "e1e8")
+
+            await engine.shutdown()
+        }
+
+        @Test("mate-in-2 returns Score.mate")
+        func mateInTwoReturnsMateScore() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let mateIn2FEN = "7k/6rQ/6K1/8/8/8/8/6R1 w - - 0 1"
+            let result = try await engine.evaluate(fen: mateIn2FEN, depth: 10)
+
+            if case .mate(let n) = result.score {
+                #expect(n >= 1 && n <= 2)
+            } else {
+                Issue.record("Expected Score.mate for mate-in-2 position, got \(result.score)")
+            }
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Integration — bestMove() Correctness
+    // ============================================================
+
+    @Suite("Integration — bestMove() Correctness",
+           .disabled("Requires real Stockfish — C stub returns zeroed results"))
+    struct BestMoveCorrectnessTests {
+
+        @Test("bestMove in starting position is a valid UCI move")
+        func bestMoveInStartingPositionIsValidUCI() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let move = try await engine.bestMove(
+                fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                depth: 10
+            )
+
+            #expect(Move(uci: move.uci) != nil)
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove for mate-in-1 is e1e8")
+        func bestMoveForMateInOneIsRe8() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let mateIn1FEN = "6k1/5ppp/8/8/8/8/5PPP/4R1K1 w - - 0 1"
+            let move = try await engine.bestMove(fen: mateIn1FEN, depth: 5)
+
+            #expect(move.uci == "e1e8")
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove captures hanging queen")
+        func bestMoveCapturesHangingQueen() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let hangingQueenFEN = "4k3/8/8/8/3q4/2P5/P7/4K3 w - - 0 1"
+            let move = try await engine.bestMove(fen: hangingQueenFEN, depth: 8)
+
+            #expect(move.uci == "c3d4")
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove for pawn promotion picks queen")
+        func bestMoveForPromotion() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let promotionFEN = "4k3/4P3/8/8/8/8/8/4K3 w - - 0 1"
+            let move = try await engine.bestMove(fen: promotionFEN, depth: 8)
+
+            #expect(move.promotion == "q")
+            #expect(move.from == "e7")
+            #expect(move.to == "e8")
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Timeout Handling
+    // ============================================================
+    // The C stub returns instantly (synchronous), so the timeout
+    // race will always lose. These tests require REAL Stockfish
+    // to produce a meaningful timeout scenario.
+
+    @Suite("Timeout Handling",
+           .disabled("Requires real Stockfish — C stub returns instantly, timeout never fires"))
+    struct TimeoutHandlingTests {
+
+        @Test("evaluate with absurdly short timeout throws evaluationTimeout")
+        func shortTimeoutThrowsEvaluationTimeout() async throws {
+            let config = try EngineConfiguration(
+                defaultDepth: 18,
+                threadCount: 1,
+                hashSizeMB: 64,
+                timeoutSeconds: 0.001
+            )
+            let engine = LucidEngine(configuration: config)
+            try await engine.start()
+
+            await #expect(throws: EngineError.evaluationTimeout) {
+                _ = try await engine.evaluate(
+                    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                    depth: 18
+                )
+            }
+
+            await engine.shutdown()
+        }
+
+        @Test("bestMove with absurdly short timeout throws evaluationTimeout")
+        func shortTimeoutThrowsOnBestMove() async throws {
+            let config = try EngineConfiguration(
+                defaultDepth: 18,
+                threadCount: 1,
+                hashSizeMB: 64,
+                timeoutSeconds: 0.001
+            )
+            let engine = LucidEngine(configuration: config)
+            try await engine.start()
+
+            await #expect(throws: EngineError.evaluationTimeout) {
+                _ = try await engine.bestMove(
+                    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                    depth: 18
+                )
+            }
+
+            await engine.shutdown()
+        }
+    }
+
+    // ============================================================
+    // MARK: - Actor Isolation and Concurrency
+    // ============================================================
+
+    @Suite("Actor Isolation")
+    struct ActorIsolationTests {
+
+        @Test("two concurrent evaluate calls both succeed")
+        func twoConcurrentEvaluateCallsBothSucceed() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+
+            let fen1 = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+            let fen2 = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
+
+            async let result1 = engine.evaluate(fen: fen1, depth: 8)
+            async let result2 = engine.evaluate(fen: fen2, depth: 8)
+
+            let (r1, r2) = try await (result1, result2)
+
+            #expect(r1.depth == 8)
+            #expect(r2.depth == 8)
+
+            await engine.shutdown()
+        }
+
+        @Test("evaluate after shutdown and restart returns valid result")
+        func evaluateAfterRestartReturnsValidResult() async throws {
+            let engine = LucidEngine()
+            try await engine.start()
+            await engine.shutdown()
+            try await engine.start()
+
+            let result = try await engine.evaluate(
+                fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                depth: 10
+            )
+
+            #expect(result.depth == 10)
+
+            await engine.shutdown()
+        }
+    }
+}

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -39,14 +39,13 @@ lucid-engine/
 │   │       └── (stockfish sources)  # [planned] Stockfish C++ source files
 │   └── LucidEngine/                  # Swift public API target
 │       ├── Engine/
-│       │   ├── LucidEngine.swift     # Actor -- configuration, isRunning, start/shutdown/ensureRunning (Issue #3)
+│       │   ├── LucidEngine.swift     # Actor -- evaluate(fen:depth:)/bestMove(fen:depth:) with FEN+depth validation, timeout via TaskGroup, C bridge mapping (Issue #3, #5)
 │       │   └── EngineError.swift     # EngineError: initializationFailed, engineNotRunning, invalidDepth, invalidFEN(String), invalidConfiguration(String), evaluationTimeout, analysisInterrupted -- Equatable, Sendable (Issue #3, #4)
 │       ├── Models/
-│       │   ├── EngineConfiguration.swift  # defaultDepth/threadCount/hashSizeMB with preconditions (Issue #3)
+│       │   ├── EngineConfiguration.swift  # defaultDepth/threadCount/hashSizeMB/timeoutSeconds(Double, default 5.0) with preconditions (Issue #3, #5)
 │       │   ├── Score.swift           # Score enum: .centipawns(Int) / .mate(Int) -- Sendable, Equatable (Issue #4)
 │       │   ├── Move.swift            # Move struct: from/to/promotion, UCI init and computed property -- Sendable, Equatable (Issue #4)
 │       │   ├── PositionAssessment.swift  # PositionAssessment struct: score/bestMove/principalVariation/depth/nodes -- Sendable, Equatable (Issue #4)
-│       │   ├── Evaluation.swift      # [planned] Single position result
 │       │   ├── MoveClassification.swift  # [planned] brilliant → blunder enum
 │       │   ├── AnalyzedMove.swift    # [planned] Per-move analysis result
 │       │   ├── GameAnalysis.swift    # [planned] Full game result
@@ -65,6 +64,7 @@ lucid-engine/
 │       ├── BridgingHeaderTests.swift            # 25 tests: constants, enums, lifecycle, preconditions (Issue #2)
 │       ├── LucidEngineLifecycleTests.swift      # 16 lifecycle tests: config, start, shutdown, restart, ensureRunning (Issue #3)
 │       ├── CoreModelsTests.swift                # 98 tests across 7 suites: Score, Move, PositionAssessment, EngineError updated cases (Issue #4)
+│       ├── PositionAssessmentTests.swift        # 10 suites: FEN validation, depth validation, default params, score mapping, integration, mate detection, bestMove, timeout, actor isolation (Issue #5)
 │       ├── MoveClassificationTests.swift        # [planned] CPL → classification mapping
 │       ├── GameAnalysisTests.swift              # [planned] Full pipeline tests
 │       └── PerformanceBenchmarkTests.swift      # [planned] Timing & memory benchmarks
@@ -84,4 +84,5 @@ lucid-engine/
 | #2 | Stockfish C bridging header -- SFStatus, SFScoreType, SFAssessResult, stub impl, 25 tests | Done |
 | #3 | LucidEngine actor with init/start/stop lifecycle -- EngineConfiguration, isRunning, ensureRunning(), 16 tests | Done |
 | #4 | Core models: Score, Move, PositionAssessment, EngineError extended cases -- 98 tests across 7 suites | Done |
-| #5 | Game analysis pipeline and move classification | Planned |
+| #5 | Single position assessment -- evaluate(fen:depth:), bestMove(fen:depth:), FEN/depth validation, timeout, C bridge mapping, 10 test suites | Done |
+| #6 | Game analysis pipeline and move classification | Planned |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,23 +142,40 @@ public actor LucidEngine {
         guard isRunning else { throw EngineError.engineNotRunning }
     }
 
-    public func assess(fen: String, depth: Int) async throws -> PositionAssessment {
-        // Actor isolation guarantees this runs serially
-        // No two assessments can overlap
+    public func evaluate(fen: String, depth: Int = 18) async throws -> PositionAssessment {
+        // Actor isolation guarantees serial access -- no two assessments can overlap.
+        // FEN and depth are validated before the C call.
+        // A TaskGroup races the assessment against a configurable timeout.
         try ensureRunning()
-        var result = SFAssessResult()
-        let status = sf_assess_position(fen, Int32(depth), &result)
-        guard status == SF_OK else { throw EngineError.initializationFailed }
-        return PositionAssessment(from: result)
+        try Self.validateFEN(fen)
+        try Self.validateDepth(depth)
+        return try await withThrowingTaskGroup(of: PositionAssessment.self) { group in
+            group.addTask { try Self.assessPosition(fen: fen, depth: depth) }
+            group.addTask { [configuration] in
+                try await Task.sleep(for: .seconds(configuration.timeoutSeconds))
+                throw EngineError.evaluationTimeout
+            }
+            guard let result = try await group.next() else {
+                throw EngineError.evaluationTimeout
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+
+    public func bestMove(fen: String, depth: Int = 18) async throws -> Move {
+        let assessment = try await evaluate(fen: fen, depth: depth)
+        return assessment.bestMove
     }
 }
 ```
 
 Benefits:
 - **Thread safety by construction** -- no locks, no races, no forgotten mutexes
-- **Natural async/await** -- callers just `await engine.assess(fen:depth:)`
+- **Natural async/await** -- callers just `await engine.evaluate(fen:depth:)` or `await engine.bestMove(fen:depth:)`
 - **Cooperative cancellation** -- `Task.isCancelled` checked between assessments
 - **Backpressure** -- actor mailbox naturally queues requests
+- **Timeout** -- each evaluation races against `configuration.timeoutSeconds` (default 5.0s) via `withThrowingTaskGroup`
 
 ---
 
@@ -263,7 +280,7 @@ let assessment = Assessment(from: result)  // copy fields into Swift value type
 |              Main Actor                   |
 |  (SwiftUI / Consumer code)               |
 |                                           |
-|  let result = await engine.assess(fen)   |
+|  let result = await engine.evaluate(fen)  |
 +-------------------+----------------------+
                     | await (suspends, non-blocking)
                     v

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -27,19 +27,19 @@ LucidEngine bridges this gap: a Swift Package that wraps Stockfish via pipe-base
 
 ## Feature Inventory
 
-| ID | Feature | Priority | Phase |
-|----|---------|----------|-------|
-| LE-01 | Core engine initialization and lifecycle | P0 | 0 - Foundation |
-| LE-02 | Single position assessment (FEN in, centipawn score out) | P0 | 0 - Foundation |
-| LE-03 | Best move calculation with principal variation | P0 | 1 - Core Analysis |
-| LE-04 | Game analysis pipeline (array of FENs in, analyzed moves out) | P1 | 1 - Core Analysis |
-| LE-05 | Move classification (brilliant/great/good/inaccuracy/mistake/blunder) | P1 | 1 - Core Analysis |
-| LE-06 | Accuracy calculation per player | P1 | 1 - Core Analysis |
-| LE-07 | Win probability curve generation | P1 | 2 - Advanced |
-| LE-08 | Game phase detection (opening/middlegame/endgame) | P2 | 2 - Advanced |
-| LE-09 | Progressive depth analysis (quick preview + deep analysis) | P2 | 2 - Advanced |
-| LE-10 | Opening book / theory detection | P3 | 3 - AI-Powered |
-| LE-11 | Natural language move explanations via AI | P3 | 3 - AI-Powered (future premium) |
+| ID | Feature | Priority | Phase | Status |
+|----|---------|----------|-------|--------|
+| LE-01 | Core engine initialization and lifecycle | P0 | 0 - Foundation | Done |
+| LE-02 | Single position assessment (FEN in, centipawn score + PositionAssessment out) | P0 | 0 - Foundation | Done |
+| LE-03 | Best move calculation with principal variation | P0 | 0 - Foundation | Done |
+| LE-04 | Game analysis pipeline (array of FENs in, analyzed moves out) | P1 | 1 - Core Analysis | Planned |
+| LE-05 | Move classification (brilliant/great/good/inaccuracy/mistake/blunder) | P1 | 1 - Core Analysis | Planned |
+| LE-06 | Accuracy calculation per player | P1 | 1 - Core Analysis | Planned |
+| LE-07 | Win probability curve generation | P1 | 2 - Advanced | Planned |
+| LE-08 | Game phase detection (opening/middlegame/endgame) | P2 | 2 - Advanced | Planned |
+| LE-09 | Progressive depth analysis (quick preview + deep analysis) | P2 | 2 - Advanced | Planned |
+| LE-10 | Opening book / theory detection | P3 | 3 - AI-Powered | Planned |
+| LE-11 | Natural language move explanations via AI | P3 | 3 - AI-Powered (future premium) | Planned |
 
 ## Dependency Graph
 
@@ -114,7 +114,7 @@ public actor LucidEngine {
     public func shutdown()
 
     /// Evaluate a single position
-    public func evaluate(fen: String, depth: Int = 18) async throws -> Evaluation
+    public func evaluate(fen: String, depth: Int = 18) async throws -> PositionAssessment
 
     /// Get the best move for a position
     public func bestMove(fen: String, depth: Int = 18) async throws -> Move
@@ -127,14 +127,15 @@ public actor LucidEngine {
 
 public struct EngineConfiguration: Sendable, Equatable {
     public static let `default`: EngineConfiguration
+    public let defaultDepth: Int     // default: 18, range: 1...100
     public let threadCount: Int      // default: 1, range: 1...64
     public let hashSizeMB: Int       // default: 64, range: 1...4096
-    public let defaultDepth: Int     // default: 18, range: 1...100
+    public let timeoutSeconds: Double // default: 5.0, must be > 0
 }
 
-// MARK: - Evaluation Result
+// MARK: - Assessment Result
 
-public struct Evaluation: Sendable {
+public struct PositionAssessment: Sendable, Equatable {
     public let score: Score
     public let bestMove: Move
     public let principalVariation: [Move]
@@ -171,7 +172,7 @@ public struct AnalyzedMove: Sendable {
     public let fen: String
     public let movePlayed: Move
     public let bestMove: Move
-    public let evaluation: Evaluation
+    public let assessment: PositionAssessment
     public let classification: MoveClassification
     public let centipawnLoss: Int
 }
@@ -211,7 +212,10 @@ public enum EngineError: Error, Sendable, Equatable {
     case initializationFailed
     case engineNotRunning
     case invalidDepth(Int)
-    case invalidFEN
+    case invalidFEN(String)
+    case invalidConfiguration(String)
+    case evaluationTimeout
+    case analysisInterrupted
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add `evaluate(fen:depth:)` and `bestMove(fen:depth:)` methods to `LucidEngine` actor with FEN validation, depth validation, C bridge mapping, and timeout handling
- Extract `FENValidator` with comprehensive 6-field FEN validation (piece placement, active color, castling, en passant, halfmove clock, fullmove number)
- Add `timeoutSeconds` to `EngineConfiguration` (default 5.0s) and `Evaluation` typealias for `PositionAssessment`
- 42 new tests across 10 suites (31 passing, 11 skipped pending real Stockfish integration)

Closes #5

## Test plan
- [x] `swift build` compiles successfully
- [x] `swift test` — 135 tests, 0 failures
- [x] FEN validation rejects invalid FENs (empty, garbage, wrong ranks, invalid pieces, bad active color)
- [x] Depth validation rejects out-of-range depths (0, negative, >100)
- [x] `evaluate()` returns correct `PositionAssessment` with requested depth
- [x] `bestMove()` delegates to `evaluate()` correctly
- [x] Actor isolation: concurrent calls succeed, restart cycle works
- [x] Integration tests skipped with `.disabled()` until real Stockfish is wired in
